### PR TITLE
v1.6.5 — emit READY <port> + CI smoke test guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.6.5] — 2026-04-28
+
+CI bite fix. Pure infrastructure — no user-facing changes from 1.6.4.
+
+### Fixed
+
+- **`READY <port>` not emitted by `zimi serve`** — the macOS / Linux
+  desktop release smoke test in CI grep'd stdout for `READY <port>`
+  to capture the bound port (needed when `--port 0` lets the OS
+  choose). Server never emitted that line, so every desktop release
+  build (v1.6.1 / v1.6.2 / v1.6.3 / v1.6.4) failed its push-trigger
+  smoke and required a manual `workflow_dispatch` re-run. Now `serve`
+  prints `READY <port>` immediately after the HTTP server binds —
+  with `flush=True` so stdout buffers don't hide it.
+
+### Tooling
+
+- **`tests/test_serve_smoke.py`** — five-test suite that subprocesses
+  `python -m zimi serve --port 0` with an empty ZIM dir and verifies
+  the contract end-to-end (READY emit, /health, /list, /search, /).
+  Runs in regular `pytest` so the failure that bit v1.6.4 surfaces
+  on the PR rather than after merge in the release pipeline.
+
 ## [1.6.4] — 2026-04-28
 
 A "hold-you-over" patch release with the most impactful bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zimi"
-version = "1.6.4"
+version = "1.6.5"
 description = "Offline knowledge server for ZIM files"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_serve_smoke.py
+++ b/tests/test_serve_smoke.py
@@ -1,0 +1,154 @@
+"""End-to-end smoke test: launch the server as a subprocess, wait for the
+READY <port> line, hit a few endpoints, shut down.
+
+This is the same contract the desktop-release CI workflow uses — by running
+it as a regular pytest, we catch a missing READY emit (or a crash on cold
+boot) on the PR rather than during the post-merge release pipeline.
+
+The previous failure mode (caught against v1.6.4): server printed
+"ZIM Reader API starting on port 0" but never emitted READY, so the
+release smoke test timed out at 30s and no DMG/AppImage/Snap got attached
+to the draft. Now this test fails loudly on the PR before merge.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+READY_RE = re.compile(rb"^READY (\d+)\s*$", re.MULTILINE)
+READY_TIMEOUT_SEC = 30
+
+
+def _wait_for_ready(proc: subprocess.Popen, log_path: str) -> int:
+    """Poll the server's stdout file for `READY <port>`. Return the port
+    or raise pytest.fail() with the captured stdout for debugging."""
+    deadline = time.time() + READY_TIMEOUT_SEC
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            with open(log_path, "rb") as f:
+                output = f.read().decode(errors="replace")
+            pytest.fail(
+                f"server exited early with code {proc.returncode}\n--- output ---\n{output}"
+            )
+        try:
+            with open(log_path, "rb") as f:
+                contents = f.read()
+        except OSError:
+            time.sleep(0.2)
+            continue
+        m = READY_RE.search(contents)
+        if m:
+            return int(m.group(1))
+        time.sleep(0.2)
+    proc.kill()
+    with open(log_path, "rb") as f:
+        output = f.read().decode(errors="replace")
+    pytest.fail(
+        f"server did not emit `READY <port>` within {READY_TIMEOUT_SEC}s\n"
+        f"--- output ---\n{output}"
+    )
+
+
+@pytest.fixture
+def serve_subprocess():
+    """Start `python -m zimi serve --port 0` with an empty ZIM dir, yield
+    (port, log_path), and clean up on teardown."""
+    tmp_zim_dir = tempfile.mkdtemp(prefix="zimi-smoke-zims-")
+    tmp_data_dir = tempfile.mkdtemp(prefix="zimi-smoke-data-")
+    log_fd, log_path = tempfile.mkstemp(prefix="zimi-smoke-log-")
+    os.close(log_fd)
+
+    env = os.environ.copy()
+    env["ZIM_DIR"] = tmp_zim_dir
+    env["ZIMI_DATA_DIR"] = tmp_data_dir
+    # Disable optional features that would pull network calls in CI.
+    env["ZIMI_AUTO_UPDATE"] = "0"
+    env["ZIMI_TORRENT"] = "0"
+    env["ZIMI_PEER_DISCOVERY"] = "0"
+    # PYTHONUNBUFFERED ensures the READY print isn't held in stdio buffers
+    # — without flush=True or this env var, CI runners can stall.
+    env["PYTHONUNBUFFERED"] = "1"
+
+    with open(log_path, "w") as log_f:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "zimi", "serve", "--port", "0"],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+        )
+
+    try:
+        port = _wait_for_ready(proc, log_path)
+        yield port, log_path
+    finally:
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+        for p in (tmp_zim_dir, tmp_data_dir):
+            shutil.rmtree(p, ignore_errors=True)
+        try:
+            os.remove(log_path)
+        except OSError:
+            pass
+
+
+def _http_get_json(url: str, timeout: float = 5.0):
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _http_status(url: str, timeout: float = 5.0) -> int:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.status
+    except urllib.error.HTTPError as e:
+        return e.code
+
+
+def test_serve_emits_ready_with_port(serve_subprocess):
+    """READY <port> must be printed to stdout once the server has bound a
+    port. CI smoke + the desktop launcher both depend on this contract."""
+    port, _log = serve_subprocess
+    assert 1 <= port <= 65535
+
+
+def test_serve_health_endpoint_responds(serve_subprocess):
+    port, _ = serve_subprocess
+    data = _http_get_json(f"http://127.0.0.1:{port}/health")
+    assert data["status"] == "ok"
+    assert "version" in data
+    assert isinstance(data.get("zim_count"), int)
+
+
+def test_serve_list_endpoint_responds(serve_subprocess):
+    """Empty ZIM dir → empty list, but the endpoint must still 200."""
+    port, _ = serve_subprocess
+    data = _http_get_json(f"http://127.0.0.1:{port}/list")
+    assert isinstance(data, list)
+
+
+def test_serve_search_endpoint_responds(serve_subprocess):
+    port, _ = serve_subprocess
+    data = _http_get_json(f"http://127.0.0.1:{port}/search?q=test&limit=1&fast=1")
+    assert "results" in data
+    assert "total" in data
+
+
+def test_serve_web_ui_responds(serve_subprocess):
+    """The `/` SPA shell must serve a 200, otherwise users see a blank screen."""
+    port, _ = serve_subprocess
+    assert _http_status(f"http://127.0.0.1:{port}/") == 200

--- a/zimi/server.py
+++ b/zimi/server.py
@@ -86,7 +86,7 @@ except ImportError:
 # SSL context using certifi CA bundle (PyInstaller bundles lack system certs)
 SSL_CTX = ssl.create_default_context(cafile=certifi.where())
 
-ZIMI_VERSION = "1.6.4"
+ZIMI_VERSION = "1.6.5"
 
 log = logging.getLogger("zimi")
 logging.basicConfig(
@@ -1018,6 +1018,11 @@ def main():
                     "Library management enabled (no password — set one in Settings for public servers)"
                 )
         server = ThreadingHTTPServer(("0.0.0.0", args.port), ZimHandler)
+        # Emit READY <actual-port> so wrapper scripts (CI smoke tests, the
+        # desktop launcher) can capture the bound port — important when
+        # --port 0 is used to let the OS pick a free port.
+        actual_port = server.server_address[1]
+        print(f"READY {actual_port}", flush=True)
         try:
             server.serve_forever()
         except KeyboardInterrupt:

--- a/zimi/static/app.js
+++ b/zimi/static/app.js
@@ -1212,11 +1212,11 @@ function _renderMoonHTML(m, wrapClass, tiltDeg, blurScale) {
     ? 'transform:translate(-50%,-50%)' + (tiltDeg ? ' rotate(' + tilt + 'deg)' : '')
     : (tiltDeg ? 'transform:rotate(' + tilt + 'deg)' : '');
   return '<div class="' + wrapClass + '"' + (rotateStyle ? ' style="' + rotateStyle + '"' : '') + '>' +
-    '<div class="' + (isHero ? 'almanac-moon-texture' : 'dc-moon-texture') + '" style="background:url(\'/static/moon.png?v=71c1b75bc1b75bc1b75b\') center/cover;opacity:0.12"></div>' +
+    '<div class="' + (isHero ? 'almanac-moon-texture' : 'dc-moon-texture') + '" style="background:url(\'/static/moon.png?v=71c1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75b\') center/cover;opacity:0.12"></div>' +
     '<div class="dc-moon-half left" style="background:' + leftColor + '"></div>' +
     '<div class="dc-moon-half right" style="background:' + rightColor + '"></div>' +
     '<div class="dc-moon-term" style="background:' + overlayColor + ';transform:scaleX(' + overlayScaleX.toFixed(3) + ')"></div>' +
-    '<div class="' + (isHero ? 'almanac-moon-texture' : 'dc-moon-texture') + '" style="background:url(\'/static/moon.png?v=71c1b75bc1b75bc1b75b\') center/cover;' +
+    '<div class="' + (isHero ? 'almanac-moon-texture' : 'dc-moon-texture') + '" style="background:url(\'/static/moon.png?v=71c1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75bc1b75b\') center/cover;' +
     (isHero ? 'mix-blend-mode:soft-light;opacity:1' : '') + '"></div>' +
     '</div>';
 }
@@ -1335,7 +1335,7 @@ function openAlmanac(replaceState) {
   }
   if (!_almanacLoaded) {
     var s = document.createElement('script');
-    s.src = '/static/almanac.js?v=05a0b10aa0b10aa0b10a';
+    s.src = '/static/almanac.js?v=05a0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10aa0b10a';
     s.onload = function() { _almanacLoaded = true; _openAlmanacInner(replaceState); };
     s.onerror = function() { console.error('Failed to load almanac.js'); };
     document.head.appendChild(s);


### PR DESCRIPTION
## Summary

Pure CI/release infrastructure fix. **No user-facing changes from 1.6.4.**

## Why

The desktop release smoke test in `.github/workflows/desktop-release.yml` waits for the server to print `READY <port>` to stdout — needed to capture the OS-assigned port when `--port 0` is used. The server never emitted that line. Every push-triggered desktop release build since v1.6.1 has hit this same failure and required a manual `workflow_dispatch` re-run. The v1.6.4 push merge left the draft release with **no DMG / AppImage / Snap attached** for the same reason.

## Fix

- **`zimi/server.py`**: print `READY <port>` (with `flush=True`) immediately after `ThreadingHTTPServer` binds, using `server.server_address[1]` to read the actual bound port.
- **`tests/test_serve_smoke.py`**: 5-test pytest suite that subprocesses `python -m zimi serve --port 0` with an empty ZIM dir and verifies the contract end-to-end (READY emit, /health, /list, /search, /). Runs in regular `pytest` so any regression of this contract **fails on the PR rather than after merge**.

## Test plan

- [x] `pytest tests/` — 288 pass (was 283; +5 new smoke tests)
- [x] JS lint clean
- [x] New smoke tests pass against the patched server

🤖 Generated with [Claude Code](https://claude.com/claude-code)