### PR TITLE
snapcraft: 1.6.1 → 1.7.0 (stale version metadata)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: zimi
 base: core22
-version: '1.6.1'
+version: '1.7.0'
 summary: Offline knowledge server for ZIM files
 description: |
   Search and read 100M+ articles offline. Wikipedia, Stack Overflow,


### PR DESCRIPTION
The freshly built snap came out named `zimi_1.6.1_amd64.snap` — snap/snapcraft.yaml's version was never bumped (v1.6.5 likely shipped mislabeled too). One line. v1.7.1 should derive this from pyproject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y97WKqARyZKB3uDfALncC8