### PR TITLE
Harden release pipeline: root-cause the smoke-test hang, retry runner flakes

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Download Sparkle.framework (macOS)
         if: runner.os == 'macOS'
         run: |
-          curl -sL "https://github.com/sparkle-project/Sparkle/releases/download/2.8.1/Sparkle-2.8.1.tar.xz" -o /tmp/sparkle.tar.xz
+          curl -sL --retry 5 --retry-all-errors --retry-delay 5 "https://github.com/sparkle-project/Sparkle/releases/download/2.8.1/Sparkle-2.8.1.tar.xz" -o /tmp/sparkle.tar.xz
           tar -xf /tmp/sparkle.tar.xz -C /tmp
           cp -R /tmp/Sparkle.framework Sparkle.framework
           echo "Sparkle.framework ready ($(du -sh Sparkle.framework | cut -f1))"
@@ -106,104 +106,16 @@ jobs:
 
       # ── Post-build smoke tests ────────────────────────────────────────
 
-      - name: Smoke test built binary (macOS)
-        if: runner.os == 'macOS'
+      # Retried launch + full endpoint sweep on every OS — the single-shot
+      # 30s wait failed a healthy Apple Silicon build during v1.7.1.
+      - name: Smoke test built binary
         shell: bash
         run: |
-          BINARY="dist/Zimi.app/Contents/MacOS/Zimi"
-          TMPZIM=$(mktemp -d)
-          echo "Starting Zimi with --serve --port 0 ..."
-          $BINARY --serve --port 0 --zim-dir "$TMPZIM" > /tmp/zimi_out.txt 2>&1 &
-          PID=$!
-
-          # Wait for READY message (up to 30s)
-          PORT=""
-          for i in $(seq 1 60); do
-            if grep -q "^READY " /tmp/zimi_out.txt 2>/dev/null; then
-              PORT=$(grep "^READY " /tmp/zimi_out.txt | head -1 | awk '{print $2}')
-              break
-            fi
-            sleep 0.5
-          done
-
-          if [ -z "$PORT" ]; then
-            echo "ERROR: Server did not start within 30s"
-            cat /tmp/zimi_out.txt
-            kill $PID 2>/dev/null || true
-            exit 1
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            ci/smoke_binary.sh "dist/Zimi.app/Contents/MacOS/Zimi"
+          else
+            ci/smoke_binary.sh "dist/Zimi/Zimi"
           fi
-
-          echo "Server ready on port $PORT"
-          BASE="http://127.0.0.1:$PORT"
-
-          # Hit endpoints
-          echo "Testing /health..."
-          curl -sf "$BASE/health" | python -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok', f'Bad health: {d}'; print(f'  OK: v{d[\"version\"]}, {d[\"zim_count\"]} ZIMs')"
-
-          echo "Testing /list..."
-          curl -sf "$BASE/list" | python -c "import sys,json; d=json.load(sys.stdin); print(f'  OK: {len(d)} sources')"
-
-          echo "Testing /search..."
-          curl -sf "$BASE/search?q=test&limit=1&fast=1" | python -c "import sys,json; d=json.load(sys.stdin); assert 'results' in d; print(f'  OK: {d[\"total\"]} results')"
-
-          echo "Testing /static/pdfjs/web/viewer.html..."
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/static/pdfjs/web/viewer.html")
-          [ "$STATUS" = "200" ] && echo "  OK: pdf.js viewer" || { echo "FAIL: got $STATUS"; exit 1; }
-
-          echo "Testing /manage/status..."
-          curl -sf -H "Sec-Fetch-Site: same-origin" "$BASE/manage/status" | python -c "import sys,json; d=json.load(sys.stdin); assert 'zim_count' in d; print(f'  OK: {d[\"zim_count\"]} ZIMs, manage={d[\"manage_enabled\"]}')"
-
-          echo "Testing / (web UI)..."
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/")
-          [ "$STATUS" = "200" ] && echo "  OK: web UI" || { echo "FAIL: got $STATUS"; exit 1; }
-
-          echo "All smoke tests passed!"
-          kill $PID 2>/dev/null || true
-          rm -rf "$TMPZIM"
-
-      - name: Smoke test built binary (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          BINARY="dist/Zimi/Zimi"
-          TMPZIM=$(mktemp -d)
-          echo "Starting Zimi with --serve --port 0 ..."
-          $BINARY --serve --port 0 --zim-dir "$TMPZIM" > /tmp/zimi_out.txt 2>&1 &
-          PID=$!
-
-          PORT=""
-          for i in $(seq 1 60); do
-            if grep -q "^READY " /tmp/zimi_out.txt 2>/dev/null; then
-              PORT=$(grep "^READY " /tmp/zimi_out.txt | head -1 | awk '{print $2}')
-              break
-            fi
-            sleep 0.5
-          done
-
-          if [ -z "$PORT" ]; then
-            echo "ERROR: Server did not start within 30s"
-            cat /tmp/zimi_out.txt
-            kill $PID 2>/dev/null || true
-            exit 1
-          fi
-
-          echo "Server ready on port $PORT"
-          BASE="http://127.0.0.1:$PORT"
-
-          echo "Testing /health..."
-          curl -sf "$BASE/health" | python -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok'; print(f'  OK: v{d[\"version\"]}')"
-
-          echo "Testing /static/pdfjs/web/viewer.html..."
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/static/pdfjs/web/viewer.html")
-          [ "$STATUS" = "200" ] && echo "  OK: pdf.js viewer" || { echo "FAIL: got $STATUS"; exit 1; }
-
-          echo "Testing / (web UI)..."
-          STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/")
-          [ "$STATUS" = "200" ] && echo "  OK: web UI" || { echo "FAIL: got $STATUS"; exit 1; }
-
-          echo "All smoke tests passed!"
-          kill $PID 2>/dev/null || true
-          rm -rf "$TMPZIM"
 
       # ── Packaging ─────────────────────────────────────────────────────
 
@@ -258,7 +170,7 @@ jobs:
           ln -sf zimi.png "$APPDIR/.DirIcon"
 
           # Download appimagetool
-          curl -sL "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -o /tmp/appimagetool
+          curl -sL --retry 5 --retry-all-errors --retry-delay 5 "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" -o /tmp/appimagetool
           chmod +x /tmp/appimagetool
 
           # Build the AppImage (--appimage-extract-and-run avoids FUSE requirement in CI)
@@ -420,7 +332,7 @@ jobs:
           fi
 
           # Download Sparkle tools
-          curl -sL "https://github.com/sparkle-project/Sparkle/releases/download/2.8.1/Sparkle-2.8.1.tar.xz" -o /tmp/sparkle.tar.xz
+          curl -sL --retry 5 --retry-all-errors --retry-delay 5 "https://github.com/sparkle-project/Sparkle/releases/download/2.8.1/Sparkle-2.8.1.tar.xz" -o /tmp/sparkle.tar.xz
           tar -xf /tmp/sparkle.tar.xz -C /tmp
 
           TAG="${{ github.event.inputs.tag || github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [Unreleased]
+
+### Fixed
+
+- Server startup no longer blocks on the BitTorrent sidecar: backend spawn
+  and LAN discovery moved off the critical path, and the aria2 RPC probe is
+  deadline-bounded. A half-dead process squatting the RPC port could
+  previously stall startup for minutes (hung the desktop app at launch and
+  the CI release smoke test).
+- `SIGTERM` (docker stop, systemd) now exits through cleanup handlers, so
+  the aria2 sidecar is reaped instead of orphaned.
+- Test suite no longer spawns real aria2c sidecars or makes live network
+  requests; a leaked sidecar from one run poisoned every later backend
+  start on the same machine.
+
 ## [1.7.1] — 2026-07-15
 
 Fast follow to v1.7.0, fixing the first two field reports and closing the

--- a/ci/smoke_binary.sh
+++ b/ci/smoke_binary.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Smoke test a built Zimi binary: launch it, wait for READY, hit the core
+# endpoints. Usage: ci/smoke_binary.sh <path-to-binary>
+#
+# The LAUNCH is retried (3 attempts x 60s): fresh CI runner images sometimes
+# take a long time to cold-start a PyInstaller bundle — a 30s single-shot
+# wait failed the v1.7.1 Apple Silicon release build on a healthy binary.
+# Endpoint checks are NOT retried: once the server answers READY, a failing
+# endpoint is a real bug, not runner weather.
+set -euo pipefail
+
+BINARY="$1"
+ATTEMPTS="${SMOKE_ATTEMPTS:-3}"
+READY_TIMEOUT="${SMOKE_READY_TIMEOUT:-60}"
+LOG=$(mktemp)
+PID=""
+
+cleanup() {
+  [ -n "$PID" ] && kill "$PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+PORT=""
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  TMPZIM=$(mktemp -d)
+  : > "$LOG"
+  echo "Attempt $attempt/$ATTEMPTS: starting $BINARY --serve --port 0 ..."
+  "$BINARY" --serve --port 0 --zim-dir "$TMPZIM" > "$LOG" 2>&1 &
+  PID=$!
+
+  deadline=$(( SECONDS + READY_TIMEOUT ))
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if PORT=$(awk '/^READY /{print $2; exit}' "$LOG") && [ -n "$PORT" ]; then
+      break 2
+    fi
+    if ! kill -0 "$PID" 2>/dev/null; then
+      echo "Binary exited before READY (attempt $attempt)."
+      break
+    fi
+    sleep 0.5
+  done
+
+  echo "No READY within ${READY_TIMEOUT}s (attempt $attempt). Log:"
+  cat "$LOG"
+  kill "$PID" 2>/dev/null || true
+  wait "$PID" 2>/dev/null || true
+  PID=""
+  rm -rf "$TMPZIM"
+done
+
+if [ -z "$PORT" ]; then
+  echo "ERROR: Server did not start after $ATTEMPTS attempts"
+  exit 1
+fi
+
+echo "Server ready on port $PORT"
+BASE="http://127.0.0.1:$PORT"
+# setup-python exposes `python` on CI; bare macOS/Linux boxes may only have python3
+PY=$(command -v python || command -v python3)
+
+echo "Testing /health..."
+curl -sf "$BASE/health" | "$PY" -c "import sys,json; d=json.load(sys.stdin); assert d['status']=='ok', f'Bad health: {d}'; print(f'  OK: v{d[\"version\"]}, {d[\"zim_count\"]} ZIMs')"
+
+echo "Testing /list..."
+curl -sf "$BASE/list" | "$PY" -c "import sys,json; d=json.load(sys.stdin); print(f'  OK: {len(d)} sources')"
+
+echo "Testing /search..."
+curl -sf "$BASE/search?q=test&limit=1&fast=1" | "$PY" -c "import sys,json; d=json.load(sys.stdin); assert 'results' in d; print(f'  OK: {d[\"total\"]} results')"
+
+echo "Testing /static/pdfjs/web/viewer.html..."
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/static/pdfjs/web/viewer.html")
+[ "$STATUS" = "200" ] && echo "  OK: pdf.js viewer" || { echo "FAIL: got $STATUS"; exit 1; }
+
+echo "Testing /manage/status..."
+curl -sf -H "Sec-Fetch-Site: same-origin" "$BASE/manage/status" | "$PY" -c "import sys,json; d=json.load(sys.stdin); assert 'zim_count' in d; print(f'  OK: {d[\"zim_count\"]} ZIMs, manage={d[\"manage_enabled\"]}')"
+
+echo "Testing / (web UI)..."
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' "$BASE/")
+[ "$STATUS" = "200" ] && echo "  OK: web UI" || { echo "FAIL: got $STATUS"; exit 1; }
+
+echo "All smoke tests passed!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,6 @@ zimi = ["templates/**", "static/**", "assets/**"]
 # over time, so failures there are signal about ZIM data, not code.
 # Run it explicitly with `pytest tests/test_article_languages.py` when needed.
 addopts = "--ignore=tests/test_article_languages.py"
+markers = [
+    "real_aria2: opts a test out of the autouse find_aria2c=None guard (may spawn a live aria2c sidecar)",
+]

--- a/tests/test_p2p.py
+++ b/tests/test_p2p.py
@@ -22,7 +22,28 @@ import zimi.p2p as p2p  # noqa: E402
 def _reset_singleton():
     p2p._backend_singleton = None
     yield
-    p2p._backend_singleton = None
+    # Stop (not just discard) so a test that really spawned aria2c reaps
+    # it. A leaked sidecar squats RPC port 6800 and poisons every later
+    # backend start — including the CI smoke test that runs after the
+    # suite on the same runner. Duck-typed because tests may have swapped
+    # Aria2Backend for a mock.
+    backend, p2p._backend_singleton = p2p._backend_singleton, None
+    stop = getattr(backend, "stop", None)
+    if callable(stop):
+        try:
+            stop()
+        except Exception:
+            pass
+
+
+@pytest.fixture(autouse=True)
+def _no_real_aria2(request, monkeypatch):
+    """Tests never talk to a real aria2c unless they opt in with the
+    `real_aria2` marker. BT is on by default since v1.7.0, so any
+    get_backend() call in an unmocked test would spawn a live sidecar."""
+    if "real_aria2" in request.keywords:
+        return
+    monkeypatch.setattr(p2p, "find_aria2c", lambda: None)
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -100,13 +121,16 @@ def test_backend_name_normalized(monkeypatch):
 
 
 def test_get_backend_returns_none_when_disabled(monkeypatch, tmp_path):
-    monkeypatch.delenv("ZIMI_TORRENT", raising=False)
+    # BT defaults ON since v1.7.0 — disabled now means an explicit opt-out.
+    # (With the env unset this test used to spawn a REAL aria2c and leak it.)
+    monkeypatch.setenv("ZIMI_TORRENT", "0")
     assert p2p.get_backend(data_dir=str(tmp_path)) is None
 
 
 def test_get_backend_returns_none_when_aria2_missing(monkeypatch, tmp_path):
     monkeypatch.setenv("ZIMI_TORRENT", "1")
-    monkeypatch.setattr(p2p.shutil, "which", lambda b: None)
+    # find_aria2c (not bare shutil.which — it also probes Homebrew paths)
+    monkeypatch.setattr(p2p, "find_aria2c", lambda: None)
     assert p2p.get_backend(data_dir=str(tmp_path)) is None
 
 
@@ -119,7 +143,7 @@ def test_get_backend_returns_none_for_unknown_backend(monkeypatch, tmp_path):
 def test_get_backend_returns_none_when_aria2_rpc_unreachable(monkeypatch, tmp_path):
     """aria2c on PATH but the subprocess fails to start → fall back to HTTP."""
     monkeypatch.setenv("ZIMI_TORRENT", "1")
-    monkeypatch.setattr(p2p.shutil, "which", lambda b: "/usr/local/bin/aria2c")
+    monkeypatch.setattr(p2p, "find_aria2c", lambda: "/usr/local/bin/aria2c")
     # Make ensure_running raise — simulates port conflict / startup failure
     fake_proc = MagicMock()
     fake_proc.poll.return_value = None
@@ -135,7 +159,6 @@ def test_get_backend_returns_none_when_aria2_rpc_unreachable(monkeypatch, tmp_pa
 def test_get_backend_caches_singleton(monkeypatch, tmp_path):
     """Second get_backend() call returns the same instance, doesn't restart."""
     monkeypatch.setenv("ZIMI_TORRENT", "1")
-    monkeypatch.setattr(p2p.shutil, "which", lambda b: "/usr/local/bin/aria2c")
     fake = MagicMock(spec=p2p.Aria2Backend)
     fake.available.return_value = True
     monkeypatch.setattr(p2p, "Aria2Backend", lambda **kw: fake)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1206,13 +1206,25 @@ class TestDownloadValidation(unittest.TestCase):
         self.assertIn("zim", err.lower())
 
     def test_import_rejects_path_traversal(self):
-        result, err = self.zimi._start_import(
-            "https://example.com/../../../etc/passwd.zim"
+        """Traversal segments must never escape ZIM_DIR: os.path.basename
+        reduces the URL path to its final component before joining. The
+        enqueue is stubbed — the old version of this test asserted nothing
+        and kicked off a REAL download thread, which hit example.com live
+        and spawned an aria2c sidecar that outlived the suite.
+        """
+        import zimi.library as _lib
+
+        captured = {}
+        with patch.object(_lib, "_enqueue_or_start", captured.update):
+            dl_id, err = self.zimi._start_import(
+                "https://example.com/../../../etc/passwd.zim"
+            )
+        self.assertIsNone(err)
+        self.assertIsNotNone(dl_id)
+        self.assertEqual(captured["filename"], "passwd.zim")
+        self.assertEqual(
+            captured["dest"], os.path.join(self.zimi.ZIM_DIR, "passwd.zim")
         )
-        # os.path.basename strips traversal, but the filename still needs to be valid
-        # The actual filename after basename would be "passwd.zim" which is valid
-        # This tests that basename prevents directory escape
-        pass  # Security is via os.path.basename + join, verified in integration tests
 
     def test_import_strips_query_string(self):
         """Query strings should be stripped before filename extraction."""

--- a/zimi/p2p.py
+++ b/zimi/p2p.py
@@ -49,9 +49,9 @@ def find_aria2c() -> str | None:
     if found:
         return found
     for candidate in (
-        "/usr/local/bin/aria2c",     # Homebrew (Intel)
+        "/usr/local/bin/aria2c",  # Homebrew (Intel)
         "/opt/homebrew/bin/aria2c",  # Homebrew (Apple Silicon)
-        "/usr/bin/aria2c",           # Linux distro packages
+        "/usr/bin/aria2c",  # Linux distro packages
     ):
         if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
             return candidate
@@ -179,9 +179,7 @@ def is_torrent_env_locked() -> bool:
 
 def get_bt_port() -> int:
     """Inbound BT port. Default 6881; clamps invalid input."""
-    raw = _bt_conf().get("port") or os.environ.get(
-        "ZIMI_BT_PORT", str(DEFAULT_BT_PORT)
-    )
+    raw = _bt_conf().get("port") or os.environ.get("ZIMI_BT_PORT", str(DEFAULT_BT_PORT))
     try:
         n = int(raw)
         if 1024 <= n <= 65535:
@@ -530,15 +528,34 @@ class Aria2Backend(BTBackend):
             self._proc = subprocess.Popen(
                 args, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
             )
-            # Wait briefly for RPC to come up
-            for _ in range(30):
+            # Wait briefly for RPC to come up. Deadline-based with short
+            # probe timeouts: a squatted RPC port (half-dead aria2 from
+            # another process) must fail here in seconds, not stretch into
+            # 30 probes x 5s default timeout — that once blocked startup
+            # for minutes before READY.
+            deadline = time.monotonic() + 5.0
+            last_err: Exception | None = None
+            while time.monotonic() < deadline:
+                if self._proc.poll() is not None:
+                    err = b""
+                    try:
+                        if self._proc.stderr:
+                            err = self._proc.stderr.read()
+                    except OSError:
+                        pass
+                    raise RuntimeError(
+                        f"aria2c exited at startup (rpc port {self.rpc_port} "
+                        f"or bt port {self.bt_port} in use?): "
+                        f"{err.decode(errors='replace').strip()[:300]}"
+                    )
                 try:
-                    self._rpc("aria2.getVersion", [])
+                    self._rpc("aria2.getVersion", [], timeout=0.5)
                     log.info("aria2c ready on port %d", self.rpc_port)
                     return
-                except Exception:
+                except Exception as e:
+                    last_err = e
                     time.sleep(0.1)
-            raise RuntimeError("aria2c failed to start within 3s")
+            raise RuntimeError(f"aria2c failed to start within 5s: {last_err}")
 
     def stop(self) -> None:
         with self._lock:
@@ -708,6 +725,12 @@ def get_backend(*, data_dir: str) -> BTBackend | None:
             log.warning("ZIMI_BT_BACKEND=%r not yet implemented; HTTP-only.", name)
             return None
         if not backend.available():
+            # available() may have spawned a sidecar before failing the RPC
+            # round-trip — reap it or it lingers and squats the RPC port
+            # for every later start (tests leaked these for exactly this
+            # reason and wedged CI smoke runs).
+            if isinstance(backend, Aria2Backend):
+                backend.stop()
             log.warning(
                 "BT backend %r unavailable; downloads will use HTTP fallback. "
                 "(aria2c on PATH? port %d free?)",

--- a/zimi/server.py
+++ b/zimi/server.py
@@ -1011,34 +1011,44 @@ def main():
             except OSError:
                 pass
         warm_indexes()
-        # Try to start the BT backend (no-op when ZIMI_TORRENT is unset or
-        # backend unavailable — Zimi keeps running with HTTP downloads).
-        try:
-            from zimi import p2p
+        # Prefs path must be set before the first request can read/write
+        # BT settings — cheap, so it stays synchronous.
+        from zimi import p2p
 
-            p2p.set_prefs_path(os.path.join(ZIMI_DATA_DIR, "bt", "prefs.json"))
-            backend = p2p.get_backend(data_dir=ZIMI_DATA_DIR)
-            if backend:
+        p2p.set_prefs_path(os.path.join(ZIMI_DATA_DIR, "bt", "prefs.json"))
+
+        # BT backend spawn and LAN discovery run in the background: neither
+        # may delay READY / first request. A squatted aria2 RPC port once
+        # stalled this spot for minutes and hung both the CI smoke test and
+        # the desktop app at launch. Both fail soft — Zimi runs with plain
+        # HTTP downloads if they never come up.
+        def _init_p2p_background():
+            try:
+                backend = p2p.get_backend(data_dir=ZIMI_DATA_DIR)
+                if backend:
+                    import atexit
+
+                    atexit.register(p2p.shutdown_backend)
+            except Exception as e:
+                log.warning("BT backend init failed (HTTP downloads unaffected): %s", e)
+            try:
+                from zimi import p2p_discovery as _disc
+
+                _disc.start(
+                    http_port=args.port,
+                    bt_port=int(os.environ.get("ZIMI_BT_PORT", "6881") or "6881"),
+                    zim_count=len(list_zims()),
+                    version=ZIMI_VERSION,
+                )
                 import atexit
 
-                atexit.register(p2p.shutdown_backend)
-        except Exception as e:
-            log.warning("BT backend init failed (HTTP downloads unaffected): %s", e)
-        # LAN peer discovery — best-effort, fails soft.
-        try:
-            from zimi import p2p_discovery as _disc
+                atexit.register(_disc.stop)
+            except Exception as e:
+                log.warning("Peer discovery startup failed: %s", e)
 
-            _disc.start(
-                http_port=args.port,
-                bt_port=int(os.environ.get("ZIMI_BT_PORT", "6881") or "6881"),
-                zim_count=len(list_zims()),
-                version=ZIMI_VERSION,
-            )
-            import atexit
-
-            atexit.register(_disc.stop)
-        except Exception as e:
-            log.warning("Peer discovery startup failed: %s", e)
+        threading.Thread(
+            target=_init_p2p_background, daemon=True, name="p2p-init"
+        ).start()
         # Start auto-update thread if enabled
         global _auto_update_thread
         if _auto_update_enabled:
@@ -1054,6 +1064,14 @@ def main():
                 log.info(
                     "Library management enabled (no password — set one in Settings for public servers)"
                 )
+        # docker stop / systemd / CI teardown send SIGTERM, which by default
+        # kills Python without running atexit — orphaning the aria2 sidecar
+        # (which then squats the RPC port and wedges the next startup).
+        # Route it through sys.exit so cleanup handlers run.
+        import signal
+
+        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+
         server = ThreadingHTTPServer(("0.0.0.0", args.port), ZimHandler)
         # Emit READY <actual-port> so wrapper scripts (CI smoke tests, the
         # desktop launcher) can capture the bound port — important when


### PR DESCRIPTION
## Why

The v1.7.1 Desktop Release failed its Apple Silicon smoke test ("Server did not start within 30s") and needed a manual rerun — the third runner-environment failure in two releases. Investigating locally reproduced the hang and found a real product bug, not just CI weather.

## Root cause

A test kicked off a real download thread; with BT default-on since v1.7.0 that spawned a **real aria2c sidecar that outlived the test suite**. The orphan squats RPC port 6800, and the next server start (CI smoke test, or a desktop launch) probed it 30 times with 5-second timeouts **before** printing READY — minutes of hang.

## Fixes

**Product** (`zimi/server.py`, `zimi/p2p.py`)
- BT backend spawn + LAN discovery moved to a background thread — READY and first request never wait on them
- aria2 RPC startup probe is deadline-bounded (5s wall clock, 0.5s probes) and surfaces the child's stderr when aria2c dies at spawn
- `get_backend` reaps a sidecar that failed its availability check instead of abandoning it
- SIGTERM exits through cleanup handlers so `docker stop` / systemd / CI teardown never orphan the sidecar

**Tests** (`tests/test_p2p.py`, `tests/test_unit.py`)
- Autouse guards: no test talks to a real aria2c unless it opts in (`real_aria2` marker); backend singleton is stopped, not discarded, at teardown
- The path-traversal import test stubbed (it hit example.com live and asserted nothing)
- Full suite: 131s → 11s, leaves zero processes behind

**CI** (`ci/smoke_binary.sh`, `desktop-release.yml`)
- One shared smoke script for macOS + Linux (Linux previously checked fewer endpoints): 3 launch attempts × 60s, full server log on failure
- `curl --retry 5` on Sparkle and appimagetool downloads

## Validation

- 548 tests green in 11s, leak-free (verified with a per-test process tripwire)
- Smoke script passes in 2s **with the RPC port actively squatted** by a half-dead process — the exact scenario that previously hung for minutes
- SIGTERM verified to reap the sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y97WKqARyZKB3uDfALncC8