### PR TITLE
Windows has never been tested; the gate is now the release matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,20 +85,35 @@ jobs:
               print(f'Wheel OK: {len(names)} files')
           "
 
-  # The environment the DESKTOP release builds in, on every pull request.
+  # The environment the DESKTOP release builds in, on every pull request, on
+  # every runner it builds on.
   #
-  # 1.9.0 was tagged, and its desktop build then failed on all four runners at
-  # this exact step: the suite had never run in this dependency set, because
-  # Desktop Release only fires on a tag and the step was added after the last
-  # one. Nothing was wrong with the code the `test` job installs; three tests
-  # needed an extra this environment does not have, and every test that boots
-  # a server timed out. Finding that after the tag is finding it too late.
+  # This job exists because 1.9.0 was tagged twice and Desktop Release failed
+  # both times, on failures a pull request had no way to see: Desktop Release
+  # fires only on a tag, and it is the only thing that installs the desktop
+  # dependency set or runs the suite anywhere but ubuntu-latest.
+  #
+  # It was first written as ONE ubuntu-latest job, which was still an
+  # approximation of the gate rather than the gate, and the next tag proved it:
+  # the release's Linux leg is pinned to ubuntu-22.04 (see the comment on that
+  # pin in desktop-release.yml) where an apt package has a different name, and
+  # the Windows and macOS suites had not run since 1.8.2. An approximate gate
+  # finds approximate problems.
+  #
+  # So the matrix here is the release's matrix. When one changes, both change:
+  # tests/test_ci_contract.py fails if the runner lists drift apart.
   #
   # Deliberately NOT `pip install -e .[pdf,mcp]`: the point is the desktop
-  # requirements exactly as the release builds them, plus libtorrent, which is
-  # bundled there and nowhere else in CI.
+  # requirements exactly as the release installs them, plus libtorrent, which
+  # is bundled there and nowhere else in CI.
   desktop-env:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-15-intel, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -109,27 +124,48 @@ jobs:
       # The same system libraries the release build installs on Linux: the
       # bundle links GTK and WebKit through PyGObject, and PyInstaller
       # collects what is present at build time.
-      - name: Install system dependencies
+      #
+      # The package is libgirepository1.0-dev on 22.04 and libgirepository-2.0-dev
+      # from 24.04 on. The release pins 22.04 for the snap base, so name both and
+      # take whichever this runner has, rather than encoding a name that goes
+      # stale the next time the pin moves.
+      - name: Install system dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libgirepository-2.0-dev \
             gir1.2-gtk-3.0 \
             gir1.2-webkit2-4.1 \
             gcc libcairo2-dev pkg-config python3-dev
+          sudo apt-get install -y libgirepository-2.0-dev \
+            || sudo apt-get install -y libgirepository1.0-dev
 
       - name: Install desktop dependencies
+        run: pip install -r desktop/requirements-desktop.txt pytest
+
+      - name: Install libtorrent (in-process BT engine)
+        shell: bash
         run: |
-          pip install -r desktop/requirements-desktop.txt pytest PyGObject
-          pip install "libtorrent==2.0.*" || echo "::warning::no libtorrent wheel here"
+          # Soft dependency, exactly as the release treats it: no wheel for this
+          # platform means the build ships HTTP-only, never that it fails.
+          pip install "libtorrent==2.0.*" || echo "::warning::no libtorrent wheel for this platform"
 
+      - name: Install PyGObject (Linux)
+        if: runner.os == 'Linux'
+        run: pip install PyGObject
+
+      # -v, not -q, and the reason is specific: a hard interpreter crash prints
+      # no failure summary at all. The Windows leg of the 1.9.0 tag died at 30%
+      # of the suite with nothing but an exit code, and the only way to know
+      # which test was running is to have streamed its name before it ran.
       - name: Run the test suite as the desktop build runs it
-        run: python -m pytest tests/ -q
+        run: python -m pytest tests/ -v -rf
 
-      # PyInstaller on one platform. The four-platform matrix stays on the tag;
-      # this is here to catch a bundle that stops building at all, which is the
-      # other way Desktop Release fails after a merge rather than before it.
+      # PyInstaller on the runner the AppImage and snap are actually built on.
+      # This catches a bundle that stops building at all, which is the other
+      # way Desktop Release fails after a merge rather than before it.
       - name: Build with PyInstaller
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           pip install pyinstaller
           pyinstaller --noconfirm desktop/zimi_desktop.spec
@@ -137,6 +173,7 @@ jobs:
       # The same script the release runs, in the same headless server mode.
       # The bundle opens a window without it, and there is no display here.
       - name: The built binary starts and answers
+        if: matrix.os == 'ubuntu-22.04'
         shell: bash
         env:
           SMOKE_EXPECT_BT: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,16 +150,20 @@ jobs:
           # platform means the build ships HTTP-only, never that it fails.
           pip install "libtorrent==2.0.*" || echo "::warning::no libtorrent wheel for this platform"
 
+      # Pinned below 3.52, which is where PyGObject started requiring
+      # girepository-2.0 — a library that does not exist on 22.04 at any
+      # package name. This runner is pinned to 22.04 for the snap base, so an
+      # unpinned install resolves to a version that cannot build here.
       - name: Install PyGObject (Linux)
         if: runner.os == 'Linux'
-        run: pip install PyGObject
+        run: pip install "PyGObject<3.52"
 
       # -v, not -q, and the reason is specific: a hard interpreter crash prints
       # no failure summary at all. The Windows leg of the 1.9.0 tag died at 30%
       # of the suite with nothing but an exit code, and the only way to know
       # which test was running is to have streamed its name before it ran.
       - name: Run the test suite as the desktop build runs it
-        run: python -m pytest tests/ -v -rf
+        run: python -m pytest tests/ -v -rf --tb=short
 
       # PyInstaller on the runner the AppImage and snap are actually built on.
       # This catches a bundle that stops building at all, which is the other

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -62,15 +62,22 @@ jobs:
         with:
           python-version: '3.12'
 
+      # libgirepository is libgirepository1.0-dev on 22.04 and
+      # libgirepository-2.0-dev from 24.04 on. This job's runner is pinned to
+      # 22.04 for the snap base above, and the 24.04 name was left behind when
+      # it moved: every Linux build since has died here, before a single test
+      # ran. Name both and take whichever this runner has, so the next time the
+      # pin moves this step moves with it.
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libgirepository-2.0-dev \
             gir1.2-gtk-3.0 \
             gir1.2-webkit2-4.1 \
             gcc libcairo2-dev pkg-config python3-dev
+          sudo apt-get install -y libgirepository-2.0-dev \
+            || sudo apt-get install -y libgirepository1.0-dev
 
       - name: Install dependencies
         run: pip install -r desktop/requirements-desktop.txt

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -90,9 +90,13 @@ jobs:
           # on BT bundling.
           pip install "libtorrent==2.0.*" || echo "::warning::no libtorrent wheel for this platform — this build runs HTTP-only"
 
+      # Pinned below 3.52, which is where PyGObject started requiring
+      # girepository-2.0 — a library that does not exist on 22.04 at any
+      # package name. This runner is pinned to 22.04 for the snap base, so an
+      # unpinned install resolves to a version that cannot build here.
       - name: Install PyGObject (Linux)
         if: runner.os == 'Linux'
-        run: pip install PyGObject
+        run: pip install "PyGObject<3.52"
 
       - name: Install pytest
         run: pip install pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Zimi runs from a folder of ZIMs with no configuration, on a stick or a NAS or a 
 
 ### Fixed
 
+- **Windows.** Deleting a ZIM answered "Failed to delete file" every time. Auto-update left every superseded edition on disk, silently. A stalled capture's browser could not be killed. Every ZIM built on Windows left four index scratch files beside it, and took its entry mimetypes from the machine's registry rather than from the spec. The cause of the first three is the same: Windows will not remove or replace a file that is still open, and Zimi released the file after acting on it rather than before. The Windows test suite had never run against a release; it now runs on every pull request, next to macOS Intel, Apple silicon, and the Linux the AppImage and snap are built on.
 - **The Raspberry Pi crash (#51).** A finished download re-hashed the file and re-scanned every installed archive while holding the lock readers need. Registration is incremental now: worst lock wait 10.6s down to 0.45s, archives opened 53 down to 1. The same pattern was hunted out of bookmark export and deletion.
 - **Flavor identity in the catalog (#50).** MDWiki's maxi and video builds no longer collide into two cards both claiming Full, and Update can no longer quietly fetch a ten gigabyte edition you never installed.
 - **Real links everywhere (#49).** Logo, source tiles, search results and cards are genuine anchors: middle-click, right-click and open-in-new-tab behave like the web.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zimi
 
 [![CI](https://github.com/epheterson/Zimi/actions/workflows/ci.yml/badge.svg)](https://github.com/epheterson/Zimi/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-2643-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2652-brightgreen)](#)
 [![Lighthouse Accessibility](https://img.shields.io/badge/Lighthouse%20a11y-100%2F100-success?logo=lighthouse&logoColor=white)](docs/plans/2026-04-26-accessibility.md)
 [![WCAG 2.1 AA](https://img.shields.io/badge/WCAG%202.1-AA-blue)](docs/plans/2026-04-26-accessibility.md)
 [![i18n](https://img.shields.io/badge/i18n-10%20languages-blueviolet)](#languages)

--- a/tests/test_alive.py
+++ b/tests/test_alive.py
@@ -214,7 +214,9 @@ def test_the_convert_phase_is_derived_from_the_line_the_sidecar_prints():
 
 def test_the_convert_phase_is_one_the_client_knows():
     assert "convert" in manage.CREATE_PHASES
-    with open(os.path.join(REPO_ROOT, "zimi", "static", "create.js")) as fh:
+    with open(
+        os.path.join(REPO_ROOT, "zimi", "static", "create.js"), encoding="utf-8"
+    ) as fh:
         assert "convert: 2" in fh.read()
 
 

--- a/tests/test_backup_cli.py
+++ b/tests/test_backup_cli.py
@@ -130,8 +130,26 @@ def test_restore_reports_env_locked_auto_update_as_skipped(dirs, tmp_path):
 # ── File mode: 0600, because password hashes ──
 
 
+def _require_posix_modes(tmp_path):
+    """0600 is a POSIX guarantee, and only some platforms make it.
+
+    Windows has no mode bits on files: chmod there toggles one read-only
+    attribute and os.stat reports 0666 whatever you asked for. The bundle is
+    still protected on Windows, by the ACL it inherits from the directory it
+    is written into — a different mechanism, and not one this assertion can
+    read. Skip rather than assert a guarantee the platform never made."""
+    probe = tmp_path / ".mode-probe"
+    probe.write_text("")
+    os.chmod(probe, 0o600)
+    granted = stat.S_IMODE(os.stat(probe).st_mode)
+    probe.unlink()
+    if granted != 0o600:
+        pytest.skip("this platform does not enforce POSIX file modes")
+
+
 def test_backup_file_mode_is_0600(dirs, tmp_path):
     zim_dir, data_dir = dirs
+    _require_posix_modes(tmp_path)
     _seed_state()
     out = tmp_path / "bundle.json"
     assert (
@@ -144,6 +162,7 @@ def test_backup_tightens_a_preexisting_looser_file(dirs, tmp_path):
     """O_CREAT's mode only applies on create — overwriting an existing 0644
     file must still end at 0600, which is what the explicit chmod is for."""
     zim_dir, data_dir = dirs
+    _require_posix_modes(tmp_path)
     out = tmp_path / "bundle.json"
     out.write_text("{}")
     os.chmod(out, 0o644)

--- a/tests/test_capture_variants.py
+++ b/tests/test_capture_variants.py
@@ -19,6 +19,7 @@ import inspect
 import json
 import os
 import sys
+import tempfile
 
 import pytest
 
@@ -129,19 +130,19 @@ def test_the_fast_engine_accepts_it_and_ignores_it():
 
 
 def test_the_session_honours_off():
-    session = renderer.RenderedSession(work_dir="/tmp", capture_variants=False)
+    session = renderer.RenderedSession(work_dir=tempfile.gettempdir(), capture_variants=False)
     assert session._capture_variants is False
 
 
 def test_the_session_defaults_to_sweeping():
-    session = renderer.RenderedSession(work_dir="/tmp")
+    session = renderer.RenderedSession(work_dir=tempfile.gettempdir())
     assert session._capture_variants is renderer.VARIANT_SWEEP_DEFAULT
 
 
 def test_a_switched_off_sweep_does_not_touch_the_archive(monkeypatch):
     """The gate is checked before anything is enumerated, so an off sweep costs
     no page evaluation at all — not a sweep that runs and discards."""
-    session = renderer.RenderedSession(work_dir="/tmp", capture_variants=False)
+    session = renderer.RenderedSession(work_dir=tempfile.gettempdir(), capture_variants=False)
     # A recorder and a context would otherwise satisfy the two later guards.
     session._recorder = object()
     session._context = object()
@@ -174,11 +175,11 @@ def test_capture_tools_survives_an_engine_that_never_heard_of_it():
 def test_an_unstarted_session_claims_nothing():
     """No browser ran, so no browser version is true. Claiming one would be
     provenance invented at construction time."""
-    assert renderer.RenderedSession(work_dir="/tmp").tools == {}
+    assert renderer.RenderedSession(work_dir=tempfile.gettempdir()).tools == {}
 
 
 def test_a_started_session_names_the_browser_it_ran():
-    session = renderer.RenderedSession(work_dir="/tmp")
+    session = renderer.RenderedSession(work_dir=tempfile.gettempdir())
     session._browser_version = "140.0.7339.16"
     assert session.tools == {"chromium": "140.0.7339.16"}
     record = zimwriter.history_record("created", "page", "x", tools=session.tools)

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -150,3 +150,44 @@ def test_every_test_file_is_collectable():
     assert len(names) > 20, f"only found {len(names)} python test files"
     # The suite's own file is here, so this is at minimum self-consistent.
     assert os.path.basename(__file__) in names
+
+
+def _runners(name, job):
+    """Every runner a job's matrix expands to.
+
+    Both forms appear here: ``os: [a, b]`` in the CI matrix, and a list of
+    ``- os: x`` entries under ``include:`` in the release matrix."""
+    body = _text(name)
+    start = body.index(f"\n  {job}:")
+    nxt = re.search(r"\n  [a-z][a-z0-9_-]*:\n", body[start + 1 :])
+    block = body[start : start + 1 + nxt.start()] if nxt else body[start:]
+    block = "\n".join(
+        ln for ln in block.splitlines() if not ln.lstrip().startswith("#")
+    )
+    inline = re.search(r"^\s*os:\s*\[([^\]]+)\]", block, re.M)
+    if inline:
+        return {v.strip().strip("'\"") for v in inline.group(1).split(",")}
+    return {m.strip().strip("'\"") for m in re.findall(r"^\s*-?\s*os:\s*(\S+)", block, re.M)}
+
+
+def test_the_pr_gate_runs_on_every_runner_the_release_builds_on():
+    """The pull request gate IS the release matrix, not a sample of it.
+
+    1.9.0 was tagged twice and Desktop Release failed both times. The second
+    time, a gate had been added to catch exactly that — but it ran one job on
+    ubuntu-latest, and the release's Linux leg is pinned to ubuntu-22.04 where
+    an apt package has a different name. The Windows and macOS suites had not
+    run since 1.8.2 and had accumulated real failures nobody could see.
+
+    Any runner in one list and not the other is a platform whose failures only
+    a tag can find, which is after the version number is spent."""
+    gate = _runners("ci.yml", "desktop-env")
+    release = _runners("desktop-release.yml", "build")
+    assert gate, "ci.yml's desktop-env job no longer declares a runner matrix"
+    assert release, "desktop-release.yml's build job no longer declares a runner matrix"
+    assert gate == release, (
+        "the pull request gate and the release build no longer run on the same "
+        f"runners. Only in the gate: {sorted(gate - release) or 'none'}. Only in "
+        f"the release: {sorted(release - gate) or 'none'}. A platform in the "
+        "release alone is one whose failures cannot be seen before the tag."
+    )

--- a/tests/test_create_hygiene.py
+++ b/tests/test_create_hygiene.py
@@ -151,7 +151,7 @@ def test_kill_takes_the_driver_out_from_any_thread(tmp_path):
         assert _zimi_droppings(str(tmp_path)) == []
     finally:
         try:
-            os.kill(proc.pid, signal.SIGKILL)
+            os.kill(proc.pid, getattr(signal, 'SIGKILL', signal.SIGTERM))
         except OSError:
             pass
 
@@ -174,7 +174,7 @@ def test_shutdown_sessions_kills_every_registered_browser(tmp_path):
         assert _zimi_droppings(str(tmp_path)) == []
     finally:
         try:
-            os.kill(proc.pid, signal.SIGKILL)
+            os.kill(proc.pid, getattr(signal, 'SIGKILL', signal.SIGTERM))
         except OSError:
             pass
 

--- a/tests/test_create_jobs.py
+++ b/tests/test_create_jobs.py
@@ -268,7 +268,30 @@ def test_an_interrupted_write_leaves_no_zim_under_its_real_name(tmp_path):
 
 @pytest.fixture
 def quick_watchdog(monkeypatch):
+    """A stall window short enough that a wedged job fails inside a test.
+
+    Only for tests asserting that a silent job IS caught. A test asserting the
+    opposite needs the window wide (see patient_watchdog): the two directions
+    have opposite tolerances for a slow machine."""
     monkeypatch.setattr(manage, "CREATE_STALL_SECONDS", 0.1)
+    monkeypatch.setattr(manage, "CREATE_STALL_TICK", 0.02)
+
+
+@pytest.fixture
+def patient_watchdog(monkeypatch):
+    """A stall window far wider than the heartbeat under test.
+
+    Proving a talking job is left alone means proving a negative, and the only
+    thing separating "the watchdog respects heartbeats" from "the machine was
+    fast" is the margin between them. At a 0.1s window and a 0.02s heartbeat
+    that margin is five ticks of scheduler noise, and the macOS Intel runner
+    ate it during the 1.9.0 release build: one late sleep, and the watchdog was
+    right to call a stall.
+
+    So the heartbeat stays at 0.02s and the window goes to 2s: a hundredfold
+    margin, still a 0.4s test. A regression here has to hold the watchdog off
+    for two seconds, which no scheduler hiccup does."""
+    monkeypatch.setattr(manage, "CREATE_STALL_SECONDS", 2.0)
     monkeypatch.setattr(manage, "CREATE_STALL_TICK", 0.02)
 
 
@@ -295,7 +318,7 @@ def test_a_job_that_stops_reporting_is_failed_not_spun(
 
 
 def test_a_job_that_keeps_reporting_is_left_alone(
-    tmp_path, monkeypatch, quick_watchdog
+    tmp_path, monkeypatch, patient_watchdog
 ):
     def chatty_run(job, opts):
         for _ in range(20):

--- a/tests/test_create_jobs.py
+++ b/tests/test_create_jobs.py
@@ -972,10 +972,15 @@ def test_the_creator_sweeps_only_its_own_index_scratch(tmp_path):
 
     out = tmp_path / "site.zim.tmp"
     scratch = [
-        tmp_path / "site.zim.tmp_title.idx",
         tmp_path / "site.zim.tmp_title.idx.tmp",
         tmp_path / "site.zim.tmp_fulltext.idx",
     ]
+    # Xapian keeps a database in a DIRECTORY. Sweeping with os.remove alone
+    # left every one of them behind, which is what kept the scratch alive on
+    # Windows through three rounds of fixing the wrong half of this.
+    scratch_dir = tmp_path / "site.zim.tmp_title.idx"
+    scratch_dir.mkdir()
+    (scratch_dir / "iamglass").write_bytes(b"x")
     keep = [
         out,
         tmp_path / "site.zim",
@@ -988,4 +993,5 @@ def test_the_creator_sweeps_only_its_own_index_scratch(tmp_path):
     _sweep_creator_scratch(str(out))
 
     assert [f.name for f in scratch if f.exists()] == []
+    assert not scratch_dir.exists(), "an index directory survived the sweep"
     assert sorted(f.name for f in keep if f.exists()) == sorted(f.name for f in keep)

--- a/tests/test_create_jobs.py
+++ b/tests/test_create_jobs.py
@@ -957,3 +957,35 @@ def test_a_video_host_is_video_and_a_page_host_is_not():
     ):
         assert not claims_video_host(u), u
         assert claims_url(u), u
+
+
+def test_the_creator_sweeps_only_its_own_index_scratch(tmp_path):
+    """libzim's scratch goes, the neighbours stay.
+
+    The sweep exists because libzim unlinks `<output>_title.idx` and friends
+    as it closes, which only works where the OS permits unlinking an open
+    file. Windows does not, so a capture left four scratch files beside every
+    ZIM it made. Since the sweep deletes by prefix, what it must never do is
+    reach a file belonging to anything else — including a ZIM whose name this
+    one is a prefix of."""
+    from zimi.zimwriter import _sweep_creator_scratch
+
+    out = tmp_path / "site.zim.tmp"
+    scratch = [
+        tmp_path / "site.zim.tmp_title.idx",
+        tmp_path / "site.zim.tmp_title.idx.tmp",
+        tmp_path / "site.zim.tmp_fulltext.idx",
+    ]
+    keep = [
+        out,
+        tmp_path / "site.zim",
+        tmp_path / "site.zim.tmp2_title.idx",  # a different build
+        tmp_path / "other.zim.tmp_title.idx",  # somebody else's scratch
+    ]
+    for f in scratch + keep:
+        f.write_bytes(b"x")
+
+    _sweep_creator_scratch(str(out))
+
+    assert [f.name for f in scratch if f.exists()] == []
+    assert sorted(f.name for f in keep if f.exists()) == sorted(f.name for f in keep)

--- a/tests/test_creator_site.py
+++ b/tests/test_creator_site.py
@@ -669,7 +669,13 @@ def test_interrupt_writes_a_valid_zim_of_what_was_captured(fixture_server, tmp_p
         said.append(message)
         if not fired and message.lstrip().startswith("[1/"):
             fired.append(True)
-            os.kill(os.getpid(), signal.SIGINT)
+            # raise_signal, not os.kill(getpid(), SIGINT). On Windows os.kill
+            # does not deliver a signal at all: it calls TerminateProcess with
+            # the number as an exit code, so this line used to kill the pytest
+            # interpreter outright, mid-suite, with no failure summary and no
+            # traceback. raise_signal runs the handler the test is about, on
+            # every platform.
+            signal.raise_signal(signal.SIGINT)
 
     info = crawler.create_site_zim(
         f"{BASE}/chain/0.html", out_dir=str(tmp_path), delay=0, progress=note

--- a/tests/test_creator_site.py
+++ b/tests/test_creator_site.py
@@ -707,7 +707,9 @@ def zimit_docker(monkeypatch, tmp_path):
     def run(cmd, note, timeout=None):
         seen["runs"].append(cmd)
         note("crawl finished")
-        out_dir = cmd[cmd.index("-v") + 1].split(":")[0]
+        # rsplit: the separator is the LAST colon. A Windows host path starts
+        # "C:\\", and splitting on the first one leaves "C".
+        out_dir = cmd[cmd.index("-v") + 1].rsplit(":", 1)[0]
         with open(os.path.join(out_dir, "whatever.zim"), "wb") as fh:
             fh.write(b"ZIMITOUTPUT")
         return 0, ["crawl finished"]
@@ -806,7 +808,9 @@ def test_zimit_pull_is_announced_never_implicit(monkeypatch, tmp_path):
         if cmd[1] == "pull":
             note("Pulling from openzim/zimit")
             return 0, []
-        out_dir = cmd[cmd.index("-v") + 1].split(":")[0]
+        # rsplit: the separator is the LAST colon. A Windows host path starts
+        # "C:\\", and splitting on the first one leaves "C".
+        out_dir = cmd[cmd.index("-v") + 1].rsplit(":", 1)[0]
         with open(os.path.join(out_dir, "x.zim"), "wb") as fh:
             fh.write(b"Z")
         return 0, []

--- a/tests/test_did_you_mean.py
+++ b/tests/test_did_you_mean.py
@@ -345,6 +345,25 @@ class VocabLossyCountingTests(unittest.TestCase):
         self.assertNotIn("word", vocab)  # count 1 → pruned
 
 
+def _grow_the_index(db_path):
+    """Change a title index in a way every filesystem has to record.
+
+    One inserted row often fits in a page SQLite has already allocated, so the
+    file size does not move, and then the only evidence left is mtime — which
+    a filesystem with coarse timestamp granularity may not have advanced yet
+    either. That is a flaky test, not a real signal: it failed once on a CI
+    runner and passed everywhere else. Enough rows to add a page make the
+    change observable on any filesystem, and "the index changed" is what these
+    tests are actually about."""
+    conn = sqlite3.connect(db_path)
+    conn.executemany(
+        "INSERT INTO titles VALUES (?,?,?)",
+        [(f"A/{9000 + i}", f"New Thing {i}", f"new thing {i}") for i in range(500)],
+    )
+    conn.commit()
+    conn.close()
+
+
 class VocabCachePersistenceTests(unittest.TestCase):
     """The vocab is persisted to disk and reloaded instead of rescanned,
     as long as its signature still matches the title indexes on disk."""
@@ -374,10 +393,7 @@ class VocabCachePersistenceTests(unittest.TestCase):
         sig1 = _search._vocab_signature(self.index_dir)
         # Touch: append a row, changing size and mtime.
         db_path = os.path.join(self.index_dir, "wikipedia.db")
-        conn = sqlite3.connect(db_path)
-        conn.execute("INSERT INTO titles VALUES ('A/999','New Thing','new thing')")
-        conn.commit()
-        conn.close()
+        _grow_the_index(db_path)
         sig2 = _search._vocab_signature(self.index_dir)
         self.assertNotEqual(sig1, sig2)
 
@@ -388,10 +404,7 @@ class VocabCachePersistenceTests(unittest.TestCase):
         self.assertIsNotNone(_search._vocab_cache_load())
         # Touch the index — cache is now stale and must be rejected.
         db_path = os.path.join(self.index_dir, "wikipedia.db")
-        conn = sqlite3.connect(db_path)
-        conn.execute("INSERT INTO titles VALUES ('A/999','New Thing','new thing')")
-        conn.commit()
-        conn.close()
+        _grow_the_index(db_path)
         self.assertIsNone(_search._vocab_cache_load())
 
     def test_builder_version_bump_invalidates_cache(self):

--- a/tests/test_folder_category.py
+++ b/tests/test_folder_category.py
@@ -194,6 +194,11 @@ def test_moving_a_zim_into_a_folder_refiles_it_on_the_next_boot(zim_dir):
     assert _entry("wikem")["category"] == "Medical"  # heuristic, no folder yet
 
     os.makedirs(str(zim_dir / "emergency-prep"))
+    # Releasing first is what moving an open file requires on Windows, where
+    # the OS refuses it outright. Worth knowing: the same constraint lands on
+    # the in-app "keep ZIMs organised by folder" feature, which moves files
+    # for the user rather than asking them to.
+    server.release_zim_handles([server._zim_short_name("wikem_en_2026-01.zim")])
     shutil.move(
         str(zim_dir / "wikem_en_2026-01.zim"),
         str(zim_dir / "emergency-prep" / "wikem_en_2026-01.zim"),

--- a/tests/test_i18n_parity.py
+++ b/tests/test_i18n_parity.py
@@ -21,13 +21,13 @@ I18N_DIR = os.path.join(
 
 
 def test_all_locales_share_the_en_key_set():
-    with open(os.path.join(I18N_DIR, "en.json")) as f:
+    with open(os.path.join(I18N_DIR, "en.json"), encoding="utf-8") as f:
         en_keys = set(json.load(f))
     assert en_keys, "en.json is empty?"
     problems = []
     for path in sorted(glob.glob(os.path.join(I18N_DIR, "*.json"))):
         lang = os.path.basename(path)
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             keys = set(json.load(f))
         missing = en_keys - keys
         extra = keys - en_keys
@@ -40,7 +40,7 @@ def test_all_locales_share_the_en_key_set():
 
 def test_no_empty_values():
     for path in sorted(glob.glob(os.path.join(I18N_DIR, "*.json"))):
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
         empty = [k for k, v in data.items() if not str(v).strip()]
         assert not empty, f"{os.path.basename(path)}: empty values for {empty[:5]}"

--- a/tests/test_loadavg_throttle.py
+++ b/tests/test_loadavg_throttle.py
@@ -19,7 +19,9 @@ from zimi import search as _search  # noqa: E402
 class LoadavgThrottleTests(unittest.TestCase):
     def test_no_sleep_when_load_below_threshold(self):
         with (
-            mock.patch.object(os, "getloadavg", return_value=(0.1, 0.1, 0.1)),
+            mock.patch.object(
+                os, "getloadavg", return_value=(0.1, 0.1, 0.1), create=True
+            ),
             mock.patch.object(os, "cpu_count", return_value=4),
             mock.patch.object(time, "sleep") as sleep_mock,
         ):
@@ -53,7 +55,12 @@ class LoadavgThrottleTests(unittest.TestCase):
     def test_no_op_when_getloadavg_unavailable(self):
         # Simulate Windows: AttributeError on os.getloadavg.
         with (
-            mock.patch.object(os, "getloadavg", side_effect=AttributeError),
+            # create=True: on Windows the attribute is genuinely absent, and
+            # patch.object will not patch what is not there — so the test
+            # named for simulating Windows was the one Windows failed.
+            mock.patch.object(
+                os, "getloadavg", side_effect=AttributeError, create=True
+            ),
             mock.patch.object(time, "sleep") as sleep_mock,
         ):
             _search._loadavg_throttle()

--- a/tests/test_loadavg_throttle.py
+++ b/tests/test_loadavg_throttle.py
@@ -32,7 +32,9 @@ class LoadavgThrottleTests(unittest.TestCase):
         # 5-min load 4.0 / 4 cpus = 1.0 ratio. Above 0.8 threshold by 0.2.
         # Expected sleep = (1.0 - 0.8) * 2.0 = 0.4s.
         with (
-            mock.patch.object(os, "getloadavg", return_value=(4.0, 4.0, 4.0)),
+            mock.patch.object(
+                os, "getloadavg", return_value=(4.0, 4.0, 4.0), create=True
+            ),
             mock.patch.object(os, "cpu_count", return_value=4),
             mock.patch.object(time, "sleep") as sleep_mock,
         ):
@@ -44,7 +46,9 @@ class LoadavgThrottleTests(unittest.TestCase):
     def test_sleep_capped_at_max(self):
         # Massive overload: ratio = 10. Cap to max_sleep.
         with (
-            mock.patch.object(os, "getloadavg", return_value=(40.0, 40.0, 40.0)),
+            mock.patch.object(
+                os, "getloadavg", return_value=(40.0, 40.0, 40.0), create=True
+            ),
             mock.patch.object(os, "cpu_count", return_value=4),
             mock.patch.object(time, "sleep") as sleep_mock,
         ):
@@ -69,7 +73,9 @@ class LoadavgThrottleTests(unittest.TestCase):
     def test_disabled_via_env_var(self):
         with (
             mock.patch.dict(os.environ, {"ZIMI_INDEX_THROTTLE": "0"}, clear=False),
-            mock.patch.object(os, "getloadavg", return_value=(99.0, 99.0, 99.0)),
+            mock.patch.object(
+                os, "getloadavg", return_value=(99.0, 99.0, 99.0), create=True
+            ),
             mock.patch.object(os, "cpu_count", return_value=1),
             mock.patch.object(time, "sleep") as sleep_mock,
         ):

--- a/tests/test_new_zim.py
+++ b/tests/test_new_zim.py
@@ -110,7 +110,11 @@ def test_update_under_new_dated_filename_badges_updated(tmp_path, monkeypatch):
     original_first_seen = _entry(server._zim_list_cache)["first_seen"]
     assert abs(original_first_seen - installed) < 2.0
 
-    # The update lands: old dated file replaced by a newer dated file.
+    # The update lands: old dated file replaced by a newer dated file. The
+    # updater releases the superseded edition's handles before unlinking it
+    # (Windows refuses to remove an open file); do the same here, or this
+    # stands in for a sequence the product does not use.
+    server.release_zim_handles([server._zim_short_name(os.path.basename(old_path))])
     os.remove(old_path)
     build_fixture_zim(str(zdir / "survival_en_2026-07.zim"))
     server.load_cache(force=False)  # new filename → cache miss → update-rename

--- a/tests/test_p2p.py
+++ b/tests/test_p2p.py
@@ -98,7 +98,7 @@ def test_bt_port_invalid_falls_back(monkeypatch, val):
 
 def test_staging_dir_default(monkeypatch):
     monkeypatch.delenv("ZIMI_STAGING_DIR", raising=False)
-    assert p2p.get_staging_dir("/data") == "/data/staging"
+    assert p2p.get_staging_dir("/data") == os.path.join("/data", "staging")
 
 
 def test_staging_dir_override(monkeypatch):

--- a/tests/test_readonly_data_dir.py
+++ b/tests/test_readonly_data_dir.py
@@ -65,13 +65,39 @@ def cache_home(tmp_path, monkeypatch):
     return str(home)
 
 
+def _make_unwritable(path):
+    """Turn a directory read-only, or skip the test that asked for one.
+
+    Every test here rests on a premise the OS has to grant: a directory that
+    exists, lists, and cannot be written. Some platforms decline. Windows
+    ignores POSIX mode bits on directories outright, and so does root on
+    Linux, and in both cases chmod returns success and changes nothing — so
+    the fixture built a perfectly writable directory, the product correctly
+    did not fall back, and ten tests failed for being right.
+
+    Asserting the premise instead of assuming it is what makes these tests
+    honest anywhere they run."""
+    os.chmod(path, 0o555)
+    probe = os.path.join(str(path), ".zimi-write-probe")
+    try:
+        with open(probe, "w"):
+            pass
+    except OSError:
+        return  # genuinely unwritable, which is what the caller asked for
+    os.unlink(probe)
+    pytest.skip(
+        "this platform ignores a read-only directory mode, so the read-only "
+        "media these tests are about cannot be created here"
+    )
+
+
 @pytest.fixture
 def ro_zim_dir(tmp_path):
     """A ZIM dir on 'read-only media': exists, listable, not writable."""
     d = tmp_path / "stick"
     d.mkdir()
     (d / "dummy.zim").write_bytes(b"")  # looks like a library, never opened
-    os.chmod(d, 0o555)
+    _make_unwritable(d)
     yield str(d)
     os.chmod(d, 0o755)
 
@@ -154,8 +180,8 @@ def test_existing_readonly_state_is_bypassed_wholesale(
     state = stick / ".zimi"
     state.mkdir(parents=True)
     (state / "cache.json").write_text("{}")
-    os.chmod(state, 0o555)
-    os.chmod(stick, 0o555)
+    _make_unwritable(state)
+    _make_unwritable(stick)
     try:
         server.apply_data_paths(str(stick), None)
         with caplog.at_level("WARNING", logger="zimi"):

--- a/tests/test_readonly_data_dir.py
+++ b/tests/test_readonly_data_dir.py
@@ -323,7 +323,7 @@ def ro_data_dir(tmp_path):
     afterwards — the state a read-only boot WITHOUT the fallback would hit."""
     d = tmp_path / "rodata"
     d.mkdir()
-    os.chmod(d, 0o555)
+    _make_unwritable(d)
     saved = server.ZIMI_DATA_DIR
     server.ZIMI_DATA_DIR = str(d)
     manage._env_pw_hash_cache = None

--- a/tests/test_register_zim_incremental.py
+++ b/tests/test_register_zim_incremental.py
@@ -122,6 +122,7 @@ def test_register_update_inherits_first_seen_and_stamps_updated(tmp_path, monkey
     # The download machinery removes older versions before registering.
     new_path = str(zdir / "existing0_en_2026-07.zim")
     build_fixture_zim(new_path)
+    server.release_zim_handles([server._zim_short_name(old_file)])
     os.remove(str(zdir / old_file))
     assert server.register_zim_file(new_path, removed_files=[old_file]) is True
 

--- a/tests/test_serve_smoke.py
+++ b/tests/test_serve_smoke.py
@@ -193,3 +193,63 @@ def test_sw_asset_version_is_content_hashed():
     src = open("zimi/static/sw.js").read()
     assert "zimi-vdev" in src  # placeholder present in source
     assert token not in src  # real token only injected at serve time
+
+
+def test_serve_survives_a_console_that_cannot_encode_its_own_banner():
+    """A boot banner must never be able to kill the server.
+
+    Windows redirects stdout at the locale encoding, cp1252, which has no box
+    drawing characters — and 1.9.0's first-run security banner (the setup key
+    from GHSA-5mw2-53vv-9pw6) is drawn in them. So on Windows the very first
+    `zimi serve > log.txt`, the run where no password is set yet, died with
+    UnicodeEncodeError before READY. The whole Windows suite had never run, so
+    nothing said so.
+
+    PYTHONIOENCODING reproduces it on any platform: this test fails on Linux
+    and macOS too when the fix is reverted, which is the point. A crash that
+    only one runner can see is a crash nobody sees."""
+    tmp_zim_dir = tempfile.mkdtemp(prefix="zimi-cp1252-zims-")
+    tmp_data_dir = tempfile.mkdtemp(prefix="zimi-cp1252-data-")
+    log_fd, log_path = tempfile.mkstemp(prefix="zimi-cp1252-log-")
+    os.close(log_fd)
+
+    env = os.environ.copy()
+    env["ZIM_DIR"] = tmp_zim_dir
+    env["ZIMI_DATA_DIR"] = tmp_data_dir
+    env["ZIMI_AUTO_UPDATE"] = "0"
+    env["ZIMI_TORRENT"] = "0"
+    env["ZIMI_PEER_DISCOVERY"] = "0"
+    env["PYTHONUNBUFFERED"] = "1"
+    # The whole point: a stdout that cannot represent the banner.
+    env["PYTHONIOENCODING"] = "cp1252"
+
+    with open(log_path, "w") as log_f:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "zimi", "serve", "--port", "0"],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+        )
+    try:
+        port = _wait_for_ready(proc, log_path)
+        assert port > 0
+        with open(log_path, "rb") as f:
+            out = f.read().decode("utf-8", errors="replace")
+        assert "UnicodeEncodeError" not in out
+        # The setup key is the reason the banner exists; it is ASCII, so it
+        # has to survive an encoding this narrow intact.
+        assert "SETUP KEY:" in out
+    finally:
+        try:
+            proc.terminate()
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=2)
+        for path in (tmp_zim_dir, tmp_data_dir):
+            shutil.rmtree(path, ignore_errors=True)
+        try:
+            os.unlink(log_path)
+        except OSError:
+            pass

--- a/tests/test_unregister_zim.py
+++ b/tests/test_unregister_zim.py
@@ -253,6 +253,43 @@ class TestDeleteRoute(unittest.TestCase):
         except urllib.error.HTTPError as e:
             return e.code, json.loads(e.read() or b"{}")
 
+    def test_delete_releases_the_archive_before_it_unlinks(self):
+        """Ordering, asserted where the OS does not assert it for us.
+
+        Windows refuses to unlink a file anyone still has open, so deleting a
+        ZIM answered 500 "Failed to delete file" there every time: the route
+        called os.remove first and dropped the pooled libzim Archive after.
+        POSIX does not care — the inode outlives the name — so this bug was
+        invisible on every runner that had ever executed this suite.
+
+        The fix is an ordering, so the test is an ordering: at the moment
+        os.remove is called, the pool must no longer hold this ZIM."""
+        alpha = _short(ALPHA)
+        # Open it for real first, so there is a pooled handle to release.
+        status, _ = self._request("/search?q=water&limit=5")
+        self.assertEqual(status, 200)
+        self.assertIn(alpha, server._archive_pool)
+
+        pooled_at_unlink = []
+        real_remove = os.remove
+
+        def watching_remove(path):
+            pooled_at_unlink.append(alpha in server._archive_pool)
+            return real_remove(path)
+
+        os.remove = watching_remove
+        try:
+            status, data = self._request("/manage/delete", {"filename": ALPHA})
+        finally:
+            os.remove = real_remove
+        self.assertEqual(status, 200, data)
+        self.assertEqual(
+            pooled_at_unlink,
+            [False],
+            "the delete route unlinked the file while its archive was still "
+            "pooled — Windows returns 500 for exactly this",
+        )
+
     def test_delete_never_rescans_and_the_zim_disappears(self):
         alpha = _short(ALPHA)
         status, listing = self._request("/list")

--- a/tests/test_unregister_zim.py
+++ b/tests/test_unregister_zim.py
@@ -67,13 +67,24 @@ def _short(filename):
 # ---------------------------------------------------------------------------
 
 
+def _delete_from_disk(path):
+    """Remove a ZIM the way every real caller of unregister_zim_file does.
+
+    Its contract is "the file is already gone", and the callers get there by
+    releasing the pooled handles first, because Windows refuses to unlink a
+    file anyone still has open. A bare os.remove here would set up a sequence
+    the product does not use, and fail on the platform that enforces it."""
+    server.release_zim_handles([server._zim_short_name(os.path.basename(path))])
+    os.remove(path)
+
+
 def test_unregister_drops_the_zim_without_a_rescan(tmp_path, monkeypatch):
     zdir = _setup_library(tmp_path, monkeypatch)
     alpha, beta = _short(ALPHA), _short(BETA)
     assert alpha in server._zim_files_cache
     gen_before = server._cache_generation
 
-    os.remove(str(zdir / ALPHA))
+    _delete_from_disk(str(zdir / ALPHA))
     monkeypatch.setattr(server, "load_cache", _no_rescan)
     # A removal needs no metadata, so nothing may be opened or extracted.
     monkeypatch.setattr(
@@ -97,7 +108,7 @@ def test_unregister_drops_the_disk_cache_row(tmp_path, monkeypatch):
     zdir = _setup_library(tmp_path, monkeypatch)
     assert ALPHA in (server._load_disk_cache() or {})
 
-    os.remove(str(zdir / ALPHA))
+    _delete_from_disk(str(zdir / ALPHA))
     monkeypatch.setattr(server, "load_cache", _no_rescan)
     assert server.unregister_zim_file(ALPHA) is True
 
@@ -116,7 +127,7 @@ def test_unregister_evicts_every_pooled_handle(tmp_path, monkeypatch):
         locks[alpha] = threading.Lock()
         locks[beta] = threading.Lock()
 
-    os.remove(str(zdir / ALPHA))
+    _delete_from_disk(str(zdir / ALPHA))
     monkeypatch.setattr(server, "load_cache", _no_rescan)
     assert server.unregister_zim_file(ALPHA) is True
 
@@ -135,7 +146,7 @@ def test_unregister_drops_the_domain_claims(tmp_path, monkeypatch):
         interlang, "_domain_zim_map", {"alpha.example": alpha, "beta.example": beta}
     )
 
-    os.remove(str(zdir / ALPHA))
+    _delete_from_disk(str(zdir / ALPHA))
     monkeypatch.setattr(server, "load_cache", _no_rescan)
     assert server.unregister_zim_file(ALPHA) is True
 
@@ -161,7 +172,7 @@ def test_unregister_of_a_shadowed_duplicate_leaves_the_library_alone(
     files = server._zim_files_cache or {}
     assert files[alpha] == str(zdir / ALPHA)
 
-    os.remove(str(sub / ALPHA))
+    _delete_from_disk(str(sub / ALPHA))
     monkeypatch.setattr(server, "load_cache", _no_rescan)
     assert server.unregister_zim_file(ALPHA) is True
 
@@ -180,7 +191,7 @@ def test_unregister_defers_when_a_shadowed_copy_would_be_promoted(
     sub = zdir / "backups"
     sub.mkdir()
     shutil.copy(str(zdir / ALPHA), str(sub / ALPHA))
-    os.remove(str(zdir / ALPHA))
+    _delete_from_disk(str(zdir / ALPHA))
 
     monkeypatch.setattr(server, "load_cache", _no_rescan)
     assert server.unregister_zim_file(ALPHA) is False

--- a/zimi/crawler.py
+++ b/zimi/crawler.py
@@ -94,6 +94,7 @@ from zimi.creator import (
 )
 from zimi.blocklist import blocked_phrase
 from zimi.zimwriter import (
+    guess_mime,
     _plural,
     _slug,
     add_standard_metadata,
@@ -229,7 +230,7 @@ def looks_like_a_page(url):
     (``.png``, ``.zip``, ``.css``). Extensionless and server-script URLs pass
     — the Content-Type check after the fetch is the real gate; this one only
     exists to avoid spending a request to learn what the name already said."""
-    guess = mimetypes.guess_type(urllib.parse.urlsplit(url).path)[0]
+    guess = guess_mime(urllib.parse.urlsplit(url).path, fallback=None)
     if not guess or guess in _PAGE_MIMES:
         return True
     return not (guess.startswith(_NON_PAGE_MAJORS) or guess in _NON_PAGE_MIMES)

--- a/zimi/creator.py
+++ b/zimi/creator.py
@@ -48,6 +48,7 @@ from typing import Any
 import zimi.server as _srv
 from zimi.blocklist import blocked_phrase
 from zimi.zimwriter import (
+    guess_mime,
     _CSS_URL_RE,
     _HREF_RE,
     _REL_RE,
@@ -231,7 +232,7 @@ def _page_title_from_html(text, fallback):
 
 
 def _guess_mime(name):
-    return mimetypes.guess_type(name)[0] or "application/octet-stream"
+    return guess_mime(name)
 
 
 def _fmt_bytes(n):

--- a/zimi/library.py
+++ b/zimi/library.py
@@ -3277,11 +3277,22 @@ def _post_download_finalize(dl):
                     and f != dl["filename"]
                 ):
                     try:
+                        # Release the superseded edition's pooled handles
+                        # first. Windows will not unlink a file anyone still
+                        # has open, and the reader who triggered this update
+                        # has almost certainly had it open — so this remove
+                        # failed there, into an `except OSError: pass`, and
+                        # every update silently left its predecessor on disk.
+                        # A no-op on POSIX.
+                        try:
+                            _srv.release_zim_handles([_srv._zim_short_name(f)])
+                        except Exception as e:
+                            log.debug("Handle release before removing %s: %s", f, e)
                         os.remove(os.path.join(_srv.ZIM_DIR, f))
                         removed_versions.append(f)
                         log.info("Removed old version: %s", f)
-                    except OSError:
-                        pass
+                    except OSError as e:
+                        log.warning("Could not remove old version %s: %s", f, e)
         except OSError:
             pass
     # Register ONLY the new file. The old shape here — load_cache(force=True)

--- a/zimi/manage.py
+++ b/zimi/manage.py
@@ -5462,6 +5462,15 @@ def handle_manage_post(handler, parsed, data):
                     e,
                 )
                 pass
+            # Release this ZIM's pooled handles BEFORE unlinking. Windows
+            # refuses to remove a file anyone still has open, and a pooled
+            # libzim Archive is exactly that, so Delete answered 500 there
+            # every time. A no-op on POSIX, where unlink of an open file has
+            # always worked.
+            try:
+                _srv.release_zim_handles([_srv._zim_short_name(filename)])
+            except Exception as e:
+                log.debug("Handle release before deleting %s: %s", filename, e)
             os.remove(filepath)
             log.info(f"Deleted ZIM: {filename}")
             record_activity(

--- a/zimi/renderer.py
+++ b/zimi/renderer.py
@@ -68,6 +68,7 @@ import posixpath
 import re
 import shutil
 import signal
+import sys
 import tempfile
 import threading
 import time
@@ -1900,6 +1901,38 @@ def shutdown_sessions():
             log.debug("could not kill a rendered session: %s", e)
 
 
+def _process_alive_windows(pid):
+    """Whether a pid is still running, asked the only way Windows allows.
+
+    Neither half of the POSIX answer exists here. os.WNOHANG is not defined,
+    and referring to it raises an AttributeError that the handler below it
+    does not catch, so this whole function was an exception on Windows and the
+    watchdog could never establish that anything had died. The fallback would
+    have been worse if it had been reached: os.kill on Windows does not send a
+    signal, it calls TerminateProcess with the number given — so the liveness
+    probe `os.kill(pid, 0)` would have killed the process it was asking about.
+
+    OpenProcess plus GetExitCodeProcess is the real question. STILL_ACTIVE is
+    259, which a process could in principle exit with; every implementation of
+    this check on this platform lives with that.
+    """
+    import ctypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, int(pid))
+    if not handle:
+        return False  # gone, or never ours to ask about
+    try:
+        code = ctypes.c_ulong()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _process_alive(pid):
     """Whether a pid is a process that is still RUNNING.
 
@@ -1907,6 +1940,8 @@ def _process_alive(pid):
     stays in the table as a zombie until somebody waits for it, and a zombie
     answers signal 0 exactly like a live process would. Asking without reaping
     is how "did the browser actually die?" gets the wrong answer forever."""
+    if sys.platform == "win32":
+        return _process_alive_windows(pid)
     try:
         reaped, _status = os.waitpid(pid, os.WNOHANG)
         if reaped == pid:

--- a/zimi/renderer.py
+++ b/zimi/renderer.py
@@ -83,6 +83,7 @@ from zimi.creator import (
     _strip_scripts,
 )
 from zimi.zimwriter import (
+    guess_mime,
     _MAX_ASSET_BYTES,
     _MAX_ASSETS,
     _MAX_TOTAL_ASSET_BYTES,
@@ -1130,7 +1131,14 @@ class RenderedSession:
         self._driver_pid = None
         if not pid:
             return
-        for sig, grace in ((signal.SIGTERM, KILL_GRACE), (signal.SIGKILL, KILL_GRACE)):
+        # Windows has no SIGKILL, and naming it is enough to raise: this whole
+        # method was an AttributeError there, so a stalled browser could never
+        # be taken out on the one platform where the watchdog had never run.
+        # os.kill on Windows is TerminateProcess regardless of the number, so
+        # the second rung is the same rung — harmless, and the ladder stays one
+        # shape on both platforms.
+        hard = getattr(signal, "SIGKILL", signal.SIGTERM)
+        for sig, grace in ((signal.SIGTERM, KILL_GRACE), (hard, KILL_GRACE)):
             if not _process_alive(pid):
                 return
             try:
@@ -2129,8 +2137,7 @@ def _mimetype_of(response, url=""):
     mime = raw.split(";")[0].strip().lower()
     return (
         mime
-        or mimetypes.guess_type(urllib.parse.urlsplit(url).path)[0]
-        or ("application/octet-stream")
+        or guess_mime(urllib.parse.urlsplit(url).path)
     )
 
 
@@ -2191,7 +2198,7 @@ def _typed(headers, url):
     for name in headers or ():
         if str(name).strip().lower() == "content-type":
             return headers
-    guessed, _encoding = mimetypes.guess_type(urllib.parse.urlsplit(url).path)
+    guessed = guess_mime(urllib.parse.urlsplit(url).path, fallback=None)
     if not guessed:
         return headers
     out = dict(headers or {})

--- a/zimi/server.py
+++ b/zimi/server.py
@@ -3027,6 +3027,34 @@ def register_zim_file(path, removed_files=()):
     return True
 
 
+def release_zim_handles(names):
+    """Drop the pooled archive and index handles for these short names.
+
+    Two callers, for what is one reason on POSIX and two on Windows.
+    unregister_zim_file evicts so that no future read uses a mapping of a file
+    that is gone. The delete route evicts BEFORE it unlinks, because Windows
+    refuses to remove a file that anyone still holds open, and a pooled libzim
+    Archive is exactly that: deleting a ZIM there answered 500 "Failed to
+    delete file" every time. On POSIX the early release changes nothing —
+    unlinking an open file has always worked, the inode simply outlives it.
+
+    Best effort by construction: a search thread already inside a read holds
+    its own reference, which no eviction can take away. It finishes in
+    milliseconds, and the caller reports the failure honestly if it has not.
+    """
+    with _archive_lock:
+        for n in names:
+            _archive_pool.pop(n, None)
+    with _suggest_pool_lock:
+        for n in names:
+            _suggest_pool.pop(n, None)
+            _suggest_zim_locks.pop(n, None)
+    with _fts_pool_lock:
+        for n in names:
+            _fts_pool.pop(n, None)
+            _fts_zim_locks.pop(n, None)
+
+
 def unregister_zim_file(filename):
     """Incrementally drop ONE just-deleted ZIM from the live library.
 
@@ -3093,17 +3121,7 @@ def unregister_zim_file(filename):
             # from the dicts only stops FUTURE use: a search thread already
             # holding one keeps a valid mapping of an unlinked file until it
             # finishes, which is why this needs no per-ZIM lock.
-            with _archive_lock:
-                for n in gone:
-                    _archive_pool.pop(n, None)
-            with _suggest_pool_lock:
-                for n in gone:
-                    _suggest_pool.pop(n, None)
-                    _suggest_zim_locks.pop(n, None)
-            with _fts_pool_lock:
-                for n in gone:
-                    _fts_pool.pop(n, None)
-                    _fts_zim_locks.pop(n, None)
+            release_zim_handles(gone)
         # Invalidates /w/ entry ETags and the interlang resolution caches —
         # cross-ZIM answers genuinely change when a ZIM leaves.
         _cache_generation += 1
@@ -3274,7 +3292,54 @@ def _cli_restore(path, overwrite):
         )
 
 
+# The first-run banner is drawn in box characters, and a console that cannot
+# encode one raises rather than substituting it. Windows redirects stdout at
+# the locale encoding (cp1252, no box drawing), so on Windows the very first
+# `zimi serve > log.txt` — the run where no password is set and the setup key
+# has to be shown — died with UnicodeEncodeError before it ever reached READY.
+_BANNER_ASCII = {"┌": "+", "└": "+", "─": "-", "│": "|"}
+
+
+def _stdio_takes(text, stream=None):
+    """Whether this stream can represent `text` at its own encoding."""
+    stream = stream if stream is not None else sys.stdout
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        text.encode(encoding)
+    except (UnicodeEncodeError, LookupError):
+        return False
+    return True
+
+
+def _printable(text):
+    """The same banner in characters this console will actually take."""
+    if _stdio_takes(text):
+        return text
+    for drawn, plain in _BANNER_ASCII.items():
+        text = text.replace(drawn, plain)
+    return text
+
+
+def _make_stdio_resilient():
+    """No character in any message may ever kill the server.
+
+    _printable keeps the banner legible; this is the layer under it, for the
+    log line, the traceback, and the message nobody thought about. Only the
+    error handler changes, never the encoding: a console that asked for cp1252
+    still gets cp1252, and an unrepresentable character arrives as an escape
+    rather than as an exception."""
+    for stream in (sys.stdout, sys.stderr):
+        encoding = (getattr(stream, "encoding", "") or "").lower().replace("-", "")
+        if encoding in ("utf8", "utf8mb3", "utf8mb4"):
+            continue
+        try:
+            stream.reconfigure(errors="backslashreplace")
+        except (AttributeError, OSError, ValueError):
+            pass
+
+
 def main():
+    _make_stdio_resilient()
     parser = argparse.ArgumentParser(description="ZIM Knowledge Base Reader")
     sub = parser.add_subparsers(dest="command")
 
@@ -3752,16 +3817,18 @@ def main():
                 key = _mng.ensure_setup_key()
                 log.info("Library management enabled — no admin password set yet.")
                 print(
-                    "\n"
-                    "  ┌─ Zimi first-run setup ──────────────────────────────\n"
-                    "  │  Set the admin password from this machine, or from\n"
-                    "  │  another device using this one-time setup key:\n"
-                    "  │\n"
-                    f"  │      SETUP KEY:  {key}\n"
-                    "  │\n"
-                    "  │  (also saved to the setup-key file in the data dir;\n"
-                    "  │   it stops working the moment a password is set)\n"
-                    "  └─────────────────────────────────────────────────────\n",
+                    _printable(
+                        "\n"
+                        "  ┌─ Zimi first-run setup ──────────────────────────────\n"
+                        "  │  Set the admin password from this machine, or from\n"
+                        "  │  another device using this one-time setup key:\n"
+                        "  │\n"
+                        f"  │      SETUP KEY:  {key}\n"
+                        "  │\n"
+                        "  │  (also saved to the setup-key file in the data dir;\n"
+                        "  │   it stops working the moment a password is set)\n"
+                        "  └─────────────────────────────────────────────────────\n",
+                    ),
                     flush=True,
                 )
         from zimi import sso as _sso

--- a/zimi/video.py
+++ b/zimi/video.py
@@ -47,6 +47,7 @@ from zimi.creator import (
 )
 from zimi.p2p import is_offline
 from zimi.zimwriter import (
+    guess_mime,
     _page_head,
     _plural,
     _slug,
@@ -305,7 +306,7 @@ def _fmt_date(yyyymmdd):
 def _media_mime(path):
     ext = os.path.splitext(path)[1].lower()
     return (
-        mimetypes.guess_type(path)[0]
+        guess_mime(path, fallback=None)
         or _MEDIA_MIME_FALLBACK.get(ext)
         or "application/octet-stream"
     )

--- a/zimi/zimwriter.py
+++ b/zimi/zimwriter.py
@@ -32,6 +32,7 @@ import os
 import pathlib
 import posixpath
 import re
+import shutil
 import struct
 import threading
 import time
@@ -1644,8 +1645,15 @@ def _sweep_creator_scratch(tmp_path):
             time.sleep(delay)
         stuck = []
         for name in left:
+            target = os.path.join(directory, name)
             try:
-                os.remove(os.path.join(directory, name))
+                # A Xapian index is a directory, not a file: os.remove cannot
+                # delete one, and for as long as this only called os.remove
+                # the scratch survived every sweep it was given.
+                if os.path.isdir(target):
+                    shutil.rmtree(target)
+                else:
+                    os.remove(target)
             except FileNotFoundError:
                 pass
             except OSError:
@@ -1665,6 +1673,13 @@ def atomic_zim_creator(out_path, language="eng"):
     from libzim.writer import Creator
 
     tmp_path = out_path + ".tmp"
+    # Before, as well as after. The sweep after a build is best effort by
+    # nature: libzim's index files close when its Creator is finalized, and
+    # while the CALLER's `with` is still open the caller holds a reference,
+    # so on Windows the last of them can outlive this function. Sweeping on
+    # the way in means a directory never carries more than one build's
+    # scratch, and the next build clears the last one's.
+    _sweep_creator_scratch(tmp_path)
     try:
         # Creator takes a Path; tmp_path stays a str for os.replace below.
         with Creator(pathlib.Path(tmp_path)).config_indexing(True, language) as creator:

--- a/zimi/zimwriter.py
+++ b/zimi/zimwriter.py
@@ -20,6 +20,7 @@ thread. Source READS (article HTML and asset bytes) still touch libzim
 
 import colorsys
 import contextlib
+import gc
 import datetime
 import hashlib
 import html as _html
@@ -1626,15 +1627,33 @@ def _sweep_creator_scratch(tmp_path):
     directory = os.path.dirname(tmp_path) or "."
     stem = os.path.basename(tmp_path) + "_"
     try:
-        names = os.listdir(directory)
+        left = [n for n in os.listdir(directory) if n.startswith(stem)]
     except OSError:
         return
-    for name in names:
-        if name.startswith(stem):
+    if not left:
+        return
+    # The indexer's own handles close as its objects are finalized, which does
+    # not always happen before this returns: the first sweep on Windows took
+    # three of the four files and left the fulltext index, still mapped. So
+    # collect first, and give the stragglers a moment. The waits only happen
+    # when something is genuinely still held, so a POSIX build, where the
+    # unlink always succeeds first time, pays nothing for them.
+    gc.collect()
+    for delay in (0, 0.05, 0.1, 0.2, 0.4):
+        if delay:
+            time.sleep(delay)
+        stuck = []
+        for name in left:
             try:
                 os.remove(os.path.join(directory, name))
+            except FileNotFoundError:
+                pass
             except OSError:
-                pass  # still held open; the caller has bigger problems
+                stuck.append(name)
+        left = stuck
+        if not left:
+            return
+    log.debug("index scratch still held after %s: %s", tmp_path, left)
 
 
 @contextlib.contextmanager

--- a/zimi/zimwriter.py
+++ b/zimi/zimwriter.py
@@ -26,6 +26,7 @@ import html as _html
 import io
 import json
 import logging
+import mimetypes
 import os
 import pathlib
 import posixpath
@@ -35,6 +36,21 @@ import threading
 import time
 import urllib.parse
 import zlib
+
+# Every mimetype Zimi writes into a ZIM comes from here, and deliberately not
+# from mimetypes.guess_type. That module's table is seeded from the OS: on
+# Windows mimetypes.init() reads HKEY_CLASSES_ROOT, so the answer for .zip or
+# .css depends on what the machine has installed, and a ZIM built there could
+# carry a type no other machine would produce. A private MimeTypes() copies
+# the table Python ships and nothing else, so the same capture has the same
+# entry types on every platform.
+_MIME_DB = mimetypes.MimeTypes()
+
+
+def guess_mime(name, fallback="application/octet-stream"):
+    """The mimetype of a filename or URL path, identically on every OS."""
+    return _MIME_DB.guess_type(name)[0] or fallback
+
 
 import zimi.server as _srv
 
@@ -1596,6 +1612,31 @@ def make_asset_item(path, mimetype, data):
     return cls(path, path.rsplit("/", 1)[-1], data, mimetype=mimetype, front=False)
 
 
+def _sweep_creator_scratch(tmp_path):
+    """Remove the index scratch libzim leaves beside the file it is building.
+
+    libzim writes `<output>_title.idx`, `<output>_fulltext.idx` and a `.tmp`
+    for each, then unlinks them as it closes — which works only where the OS
+    lets a process unlink a file it still has open. Windows does not, so every
+    capture left four files of litter next to the ZIM, and a cancelled capture
+    left them in a directory the caller had been promised was untouched.
+
+    Every name is derived from tmp_path, so this can only ever remove Zimi's
+    own scratch for this one build, never a neighbouring ZIM."""
+    directory = os.path.dirname(tmp_path) or "."
+    stem = os.path.basename(tmp_path) + "_"
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        return
+    for name in names:
+        if name.startswith(stem):
+            try:
+                os.remove(os.path.join(directory, name))
+            except OSError:
+                pass  # still held open; the caller has bigger problems
+
+
 @contextlib.contextmanager
 def atomic_zim_creator(out_path, language="eng"):
     """Yield a libzim Creator writing to ``<out_path>.tmp``; rename over
@@ -1617,6 +1658,8 @@ def atomic_zim_creator(out_path, language="eng"):
         except OSError:
             pass
         raise
+    finally:
+        _sweep_creator_scratch(tmp_path)
 
 
 # ── provenance ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What this found

The PR gate added for 1.9.0 was one job on ubuntu-latest standing in for the release's four-runner matrix. It passed; the tag then failed on three of four runners.

Making the gate the real matrix produced the first Windows test run in the project's history. Until the commit in this release that made CI run the whole suite, the release workflow ran `python tests/test_unit.py` (which imports the file and executes none of its tests) plus one file by name, so every Windows build ever shipped was gated by a step that could not fail.

First real run: **56 failed, 2,521 passed.** Six were the product.

## Product defects fixed

- **`zimi serve` died at boot on Windows.** The first-run banner carrying the setup key (this release's GHSA-5mw2-53vv-9pw6 fix) is drawn in box characters; Windows encodes redirected stdout as cp1252, which has none of them. The run where no password is set yet crashed before READY. Stdio no longer lets any character kill the server, and the banner degrades to ASCII. Reproduced with `PYTHONIOENCODING=cp1252`, so the test fails on every platform if this regresses.
- **Deleting a ZIM returned 500 every time.** The route unlinked the file and released the pooled libzim archive afterwards. Windows will not remove an open file. Now released first; POSIX is unaffected.
- **Auto-update orphaned every superseded edition,** same cause, inside an `except OSError: pass`, so it failed silently and permanently. The swallow is now a warning.
- **A stalled capture's browser could not be killed.** `signal.SIGKILL` does not exist on Windows and naming it raises.
- **Every ZIM built on Windows left four libzim index scratch files** beside it.
- **Entry mimetypes came from `HKEY_CLASSES_ROOT`,** so a ZIM built on Windows could carry types no other machine produces. Five call sites now share one registry-free guesser.

## Infrastructure

- `ci.yml`'s `desktop-env` runs the release matrix: ubuntu-22.04, macos-15-intel, macos-latest, windows-latest.
- `tests/test_ci_contract.py` fails if the gate's runner list and the release's ever drift apart.
- Linux apt: 22.04 calls it `libgirepository1.0-dev`, 24.04+ `libgirepository-2.0-dev`. Pinned to 22.04 for the snap base since the #55 fix while both workflows asked for the 24.04 name, so every Linux build since exited 100 before running a test. PyGObject is pinned below 3.52, which requires a girepository 22.04 does not ship.
- `os.kill(os.getpid(), SIGINT)` in the crawler interrupt test called `TerminateProcess` on Windows, killing pytest mid-suite with no summary. Now `signal.raise_signal`.
- Tests that assumed POSIX mode bits or a chmod-read-only directory now verify the premise and skip when the OS declines, which also fixes them under root on Linux.

## Verification

Local suite 2,633 passed, 19 skipped. Four-runner matrix on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

